### PR TITLE
[WIP] Add metadata to MapStatus

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputMetadata.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputMetadata.java
@@ -19,15 +19,15 @@ package org.apache.spark.shuffle.api.metadata;
 
 import org.apache.spark.annotation.DeveloperApi;
 
-import java.io.Serializable;
+import java.io.Externalizable;
 
 /**
  * :: DeveloperApi ::
  * Metadata for registering the result of committing the output of a shuffle map task.
  * <p>
- * All implementations must be serializable since this is sent from the executors to
+ * All implementations must be externalizable since this is sent from the executors to
  * the driver.
  */
 @DeveloperApi
-public interface MapOutputMetadata extends Serializable {}
+public interface MapOutputMetadata extends Externalizable {}
 

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputMetadataExternalizer.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputMetadataExternalizer.java
@@ -14,20 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.shuffle.api.metadata;
 
-import org.apache.spark.annotation.DeveloperApi;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 
-import java.io.Serializable;
+public interface MapOutputMetadataExternalizer {
 
-/**
- * :: DeveloperApi ::
- * Metadata for registering the result of committing the output of a shuffle map task.
- * <p>
- * All implementations must be serializable since this is sent from the executors to
- * the driver.
- */
-@DeveloperApi
-public interface MapOutputMetadata extends Serializable {}
+    void writeExternal(MapOutputMetadata mapOutputMetadata, ObjectOutput out) throws IOException;
 
+    MapOutputMetadata readExternal(ObjectInput in) throws IOException, ClassNotFoundException;
+}

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputMetadataFactory.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputMetadataFactory.java
@@ -16,13 +16,6 @@
  */
 package org.apache.spark.shuffle.api.metadata;
 
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-
-public interface MapOutputMetadataExternalizer {
-
-    void writeExternal(MapOutputMetadata mapOutputMetadata, ObjectOutput out) throws IOException;
-
-    MapOutputMetadata readExternal(ObjectInput in) throws IOException, ClassNotFoundException;
+public interface MapOutputMetadataFactory {
+  MapOutputMetadata create();
 }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
@@ -141,7 +141,7 @@ final class BypassMergeSortShuffleWriter<K, V>
         partitionLengths = mapOutputWriter.commitAllPartitions(
           ShuffleChecksumHelper.EMPTY_CHECKSUM_VALUE).getPartitionLengths();
         mapStatus = MapStatus$.MODULE$.apply(
-          blockManager.shuffleServerId(), partitionLengths, mapId);
+          blockManager.shuffleServerId(), partitionLengths, mapId, null);
         return;
       }
       final SerializerInstance serInstance = serializer.newInstance();
@@ -179,7 +179,7 @@ final class BypassMergeSortShuffleWriter<K, V>
 
       partitionLengths = writePartitionedData(mapOutputWriter);
       mapStatus = MapStatus$.MODULE$.apply(
-        blockManager.shuffleServerId(), partitionLengths, mapId);
+        blockManager.shuffleServerId(), partitionLengths, mapId, null);
     } catch (Exception e) {
       try {
         mapOutputWriter.abort(e);

--- a/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
@@ -231,7 +231,7 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
       }
     }
     mapStatus = MapStatus$.MODULE$.apply(
-      blockManager.shuffleServerId(), partitionLengths, mapId);
+      blockManager.shuffleServerId(), partitionLengths, mapId, null);
   }
 
   @VisibleForTesting

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -162,7 +162,7 @@ private[spark] class CompressedMapStatus(
     out.write(compressedSizes)
     out.writeLong(_mapTaskId)
     if (_metadata != null) {
-      SparkEnv.get.shuffleManager.mapOutputMetadataExternalizer.writeExternal(_metadata, out)
+      _metadata.writeExternal(out)
     }
   }
 
@@ -172,7 +172,10 @@ private[spark] class CompressedMapStatus(
     compressedSizes = new Array[Byte](len)
     in.readFully(compressedSizes)
     _mapTaskId = in.readLong()
-    _metadata = SparkEnv.get.shuffleManager.mapOutputMetadataExternalizer.readExternal(in)
+    _metadata = SparkEnv.get.shuffleManager.mapOutputMetadataFactory.create()
+    if (_metadata != null) {
+      _metadata.readExternal(in)
+    }
   }
 }
 
@@ -239,7 +242,7 @@ private[spark] class HighlyCompressedMapStatus private (
     }
     out.writeLong(_mapTaskId)
     if (_metadata != null) {
-      SparkEnv.get.shuffleManager.mapOutputMetadataExternalizer.writeExternal(_metadata, out)
+      _metadata.writeExternal(out)
     }
   }
 
@@ -258,7 +261,10 @@ private[spark] class HighlyCompressedMapStatus private (
     }
     hugeBlockSizes = hugeBlockSizesImpl
     _mapTaskId = in.readLong()
-    _metadata = SparkEnv.get.shuffleManager.mapOutputMetadataExternalizer.readExternal(in)
+    _metadata = SparkEnv.get.shuffleManager.mapOutputMetadataFactory.create()
+    if (_metadata != null) {
+      _metadata.readExternal(in)
+    }
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.shuffle
 
 import org.apache.spark.{ShuffleDependency, TaskContext}
-import org.apache.spark.shuffle.api.metadata.MapOutputMetadataExternalizer
+import org.apache.spark.shuffle.api.metadata.MapOutputMetadataFactory
 
 /**
  * Pluggable interface for shuffle systems. A ShuffleManager is created in SparkEnv on the driver
@@ -92,7 +92,7 @@ private[spark] trait ShuffleManager {
    */
   def shuffleBlockResolver: ShuffleBlockResolver
 
-  val mapOutputMetadataExternalizer: MapOutputMetadataExternalizer
+  val mapOutputMetadataFactory: MapOutputMetadataFactory
 
   /** Shut down this ShuffleManager. */
   def stop(): Unit

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.shuffle
 
 import org.apache.spark.{ShuffleDependency, TaskContext}
+import org.apache.spark.shuffle.api.metadata.MapOutputMetadataExternalizer
 
 /**
  * Pluggable interface for shuffle systems. A ShuffleManager is created in SparkEnv on the driver
@@ -90,6 +91,8 @@ private[spark] trait ShuffleManager {
    * Return a resolver capable of retrieving shuffle block data based on block coordinates.
    */
   def shuffleBlockResolver: ShuffleBlockResolver
+
+  val mapOutputMetadataExternalizer: MapOutputMetadataExternalizer
 
   /** Shut down this ShuffleManager. */
   def stop(): Unit

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleManager.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.shuffle.sort
 
-import java.io.{ObjectInput, ObjectOutput}
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
@@ -26,7 +25,7 @@ import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle._
 import org.apache.spark.shuffle.api.ShuffleExecutorComponents
-import org.apache.spark.shuffle.api.metadata.{MapOutputMetadata, MapOutputMetadataExternalizer}
+import org.apache.spark.shuffle.api.metadata.{MapOutputMetadata, MapOutputMetadataFactory}
 import org.apache.spark.util.collection.OpenHashSet
 
 /**
@@ -197,12 +196,9 @@ private[spark] class SortShuffleManager(conf: SparkConf) extends ShuffleManager 
     shuffleBlockResolver.stop()
   }
 
-  override val mapOutputMetadataExternalizer: MapOutputMetadataExternalizer = {
-    new MapOutputMetadataExternalizer {
-      override def writeExternal(mapOutputMetadata: MapOutputMetadata, out: ObjectOutput): Unit = {
-      }
-
-      override def readExternal(in: ObjectInput): MapOutputMetadata = null
+  override val mapOutputMetadataFactory: MapOutputMetadataFactory = {
+    new MapOutputMetadataFactory {
+      override def create(): MapOutputMetadata = null
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleManager.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.shuffle.sort
 
+import java.io.{ObjectInput, ObjectOutput}
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
@@ -25,6 +26,7 @@ import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle._
 import org.apache.spark.shuffle.api.ShuffleExecutorComponents
+import org.apache.spark.shuffle.api.metadata.{MapOutputMetadata, MapOutputMetadataExternalizer}
 import org.apache.spark.util.collection.OpenHashSet
 
 /**
@@ -193,6 +195,15 @@ private[spark] class SortShuffleManager(conf: SparkConf) extends ShuffleManager 
   /** Shut down this ShuffleManager. */
   override def stop(): Unit = {
     shuffleBlockResolver.stop()
+  }
+
+  override val mapOutputMetadataExternalizer: MapOutputMetadataExternalizer = {
+    new MapOutputMetadataExternalizer {
+      override def writeExternal(mapOutputMetadata: MapOutputMetadata, out: ObjectOutput): Unit = {
+      }
+
+      override def readExternal(in: ObjectInput): MapOutputMetadata = null
+    }
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark
 
-import java.io.{ObjectInput, ObjectOutput}
-
 import scala.collection.mutable.ArrayBuffer
 
 import org.mockito.ArgumentMatchers.any
@@ -33,18 +31,15 @@ import org.apache.spark.internal.config.Tests.IS_TESTING
 import org.apache.spark.rpc.{RpcAddress, RpcCallContext, RpcEnv}
 import org.apache.spark.scheduler.{CompressedMapStatus, HighlyCompressedMapStatus, MapStatus, MergeStatus}
 import org.apache.spark.shuffle.{FetchFailedException, ShuffleManager}
-import org.apache.spark.shuffle.api.metadata.{MapOutputMetadata, MapOutputMetadataExternalizer}
+import org.apache.spark.shuffle.api.metadata.{MapOutputMetadata, MapOutputMetadataFactory}
 import org.apache.spark.storage.{BlockManagerId, ShuffleBlockId, ShuffleMergedBlockId}
 
 
 class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
   private val conf = new SparkConf
 
-  private val metadataExternalizer = new MapOutputMetadataExternalizer {
-    override def writeExternal(mapOutputMetadata: MapOutputMetadata, out: ObjectOutput): Unit = {
-    }
-
-    override def readExternal(in: ObjectInput): MapOutputMetadata = null
+  private val metadataFactory = new MapOutputMetadataFactory {
+    override def create(): MapOutputMetadata = null
   }
 
   override def beforeEach(): Unit = {
@@ -53,7 +48,7 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
     SparkEnv.set(env)
     val shuffleManager = mock(classOf[ShuffleManager])
     when(env.shuffleManager).thenReturn(shuffleManager)
-    when(shuffleManager.mapOutputMetadataExternalizer).thenReturn(metadataExternalizer)
+    when(shuffleManager.mapOutputMetadataFactory).thenReturn(metadataFactory)
     when(env.conf).thenReturn(conf)
   }
 


### PR DESCRIPTION
Regarding storing and retrieving of `MapOutputMetadata` my idea was to add the metadata directly into [MapStatus](https://github.com/attilapiros/spark/blob/72f3af34bb72b1c70ba26aa0b973ce7b44c10d63/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala#L49) and delegate the serialization/deserialization of the metadata into a new class [MapOutputMetadataExternalizer](https://github.com/attilapiros/spark/blob/72f3af34bb72b1c70ba26aa0b973ce7b44c10d63/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputMetadataExternalizer.java#L23) which is constructed by the [ShuffleManager](https://github.com/attilapiros/spark/blob/72f3af34bb72b1c70ba26aa0b973ce7b44c10d63/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala#L95).

This way Uber RSS could fill location by the executor's blockmanger ID where the map was running and store the RSS related block coordinates as a custom `MapOutputMetadata`.

Advantage:

With solution a single shuffle solution can handle different kind of `MapOutputMetadata`s as the `MapOutputMetadataExternalizer#writeExternal` could write a type indicator first (single Byte for example depending on the the `MapOutputMetadata` type) and the readExternal can create the right instance depending on the indicator read

Disadvantage:

At the retrieve I had to bind the `MapStatus` location and the `MapOutputMetadata` together: 
https://github.com/attilapiros/spark/blob/72f3af34bb72b1c70ba26aa0b973ce7b44c10d63/core/src/main/scala/org/apache/spark/MapOutputTracker.scala#L1651-L1654

This feels bad. One alternative solution is to use only the `MapOutputMetadata` and forget the locations in this kind of retrieve... 

But if we need both the location and `MapOutputMetadata` then a much better solution would be https://github.com/apache/spark/pull/31876 which is stale PR but we can help on that.